### PR TITLE
Clear ports and wires on circuit load

### DIFF
--- a/client/src/store/port/actions.js
+++ b/client/src/store/port/actions.js
@@ -1,7 +1,11 @@
-import { CREATE_PORTS } from './types';
+import { CLEAR_PORTS, CREATE_PORTS } from './types';
 
 // eslint-disable-next-line import/prefer-default-export
 export const createPorts = (ports) => ({
   type: CREATE_PORTS,
   ports,
+});
+
+export const clearPorts = () => ({
+  type: CLEAR_PORTS,
 });

--- a/client/src/store/port/reducer.js
+++ b/client/src/store/port/reducer.js
@@ -1,4 +1,4 @@
-import { CREATE_PORTS } from './types';
+import { CLEAR_PORTS, CREATE_PORTS } from './types';
 
 const initialState = {
   ports: [],
@@ -9,6 +9,11 @@ const portReducer = (state = { ...initialState }, action) => {
     case CREATE_PORTS:
       state.ports.push(...action.ports);
       return { ...state };
+    case CLEAR_PORTS:
+      return {
+        ...state,
+        ports: [],
+      };
     default:
       return state;
   }

--- a/client/src/store/port/types.js
+++ b/client/src/store/port/types.js
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
 export const CREATE_PORTS = 'CREATE_PORTS';
+export const CLEAR_PORTS = 'CLEAR_PORTS';

--- a/client/src/store/websocket/middleware.js
+++ b/client/src/store/websocket/middleware.js
@@ -47,8 +47,8 @@ import {
   largeOrGateWidth,
   flipFlopSize,
 } from '../../util/style';
-import { createPorts } from '../port/actions';
-import { createWire, setWireSignal } from '../wire/actions';
+import { createPorts, clearPorts } from '../port/actions';
+import { createWire, setWireSignal, clearWires } from '../wire/actions';
 import { clearGrid, createComponent } from '../component/actions';
 
 class MessageFactory {
@@ -331,6 +331,8 @@ const wsMiddleware = () => {
         allowMessages = false;
         const circuitModel = message;
         store.dispatch(clearGrid());
+        store.dispatch(clearPorts());
+        store.dispatch(clearWires());
         for (let i = 0; i < circuitModel.length; i++) {
           const c = circuitModel[i];
 

--- a/client/src/store/wire/actions.js
+++ b/client/src/store/wire/actions.js
@@ -1,4 +1,4 @@
-import { SHOW_WIRE_PREVIEW, CREATE_WIRE, SET_WIRE_SIGNAL } from './types';
+import { SHOW_WIRE_PREVIEW, CREATE_WIRE, SET_WIRE_SIGNAL, CLEAR_WIRES } from './types';
 
 export const showWirePreview = (points) => ({
   type: SHOW_WIRE_PREVIEW,
@@ -8,6 +8,10 @@ export const showWirePreview = (points) => ({
 export const createWire = (points) => ({
   type: CREATE_WIRE,
   points,
+});
+
+export const clearWires = () => ({
+  type: CLEAR_WIRES,
 });
 
 export const setWireSignal = (id, signal) => ({

--- a/client/src/store/wire/reducer.js
+++ b/client/src/store/wire/reducer.js
@@ -5,6 +5,7 @@ import {
   LOW_SIGNAL,
   HIGH_SIGNAL,
   ERROR_SIGNAL,
+  CLEAR_WIRES,
 } from './types';
 
 const initialState = {
@@ -31,6 +32,11 @@ const wireReducer = (state = { ...initialState }, action) => {
     case CREATE_WIRE:
       state.wires.set(action.id, { points: action.points, signal: LOW_SIGNAL });
       return { ...state, isTheWirePreviewHidden: true };
+    case CLEAR_WIRES:
+      return {
+        ...state,
+        wires: new Map(),
+      };
     case SET_WIRE_SIGNAL: {
       if (state.wires.has(action.id)) {
         state.wires.get(action.id).signal = mapSignal(action.signal);

--- a/client/src/store/wire/types.js
+++ b/client/src/store/wire/types.js
@@ -1,6 +1,7 @@
 export const SHOW_WIRE_PREVIEW = 'SHOW_WIRE_PREVIEW';
 export const CREATE_WIRE = 'CREATE_WIRE';
 export const SET_WIRE_SIGNAL = 'SET_WIRE_SIGNAL';
+export const CLEAR_WIRES = 'CLEAR_WIRES';
 
 // Signal types
 export const LOW_SIGNAL = 'LOW_SIGNAL';


### PR DESCRIPTION
Add client side functionality to clear ports and wires when a circuit is loaded. Prior to this, only gates and other circuit components were being cleared on circuit load